### PR TITLE
Blind fix for ignored ScienceBuyMultiplier

### DIFF
--- a/KSPCasher/KSPCasher.cs
+++ b/KSPCasher/KSPCasher.cs
@@ -362,7 +362,7 @@ namespace KSPCasher
             }
             bool canAfford = false;
 
-            int cost = ev.host.scienceCost * 10000;
+            int cost = ev.host.scienceCost * ScienceBuyMultiplier;
 
             if (Funding.Instance.Funds >= cost) canAfford = true;
 


### PR DESCRIPTION
Not gonna install the behemoth that is visual studio on this PC to test, but don't see why this wouldn't work.